### PR TITLE
Support for custom user agent for geckoview

### DIFF
--- a/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/InAppBrowserActivity.kt
+++ b/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/InAppBrowserActivity.kt
@@ -109,6 +109,12 @@ class InAppBrowserActivity : AppCompatActivity() {
                     allowJavascript = true
                 }
 
+                val headers: Bundle? = intent.getBundleExtra("headers")
+                val customUserAgent = headers?.getString("user-agent")
+                if (customUserAgent != null) {
+                    geckoSession.settings.userAgentOverride = customUserAgent
+                }
+
                 geckoSession.navigationDelegate = object : GeckoSession.NavigationDelegate {
                     override fun onLoadRequest(
                         session: GeckoSession,

--- a/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/OpacityCore.kt
+++ b/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/OpacityCore.kt
@@ -79,7 +79,7 @@ object OpacityCore {
     }
 
     fun setBrowserHeader(key: String, value: String) {
-        headers.putString(key, value)
+        headers.putString(key.lowercase(), value)
     }
 
     fun presentBrowser() {


### PR DESCRIPTION
```            
OpacityCore.prepareInAppBrowser("https://www.google.com/search?q=what%27s+my+user+agent")
OpacityCore.setBrowserHeader("User-Agent", ""Mozilla/5.0 (iPhone; CPU iPhone OS 17_7_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.4 Mobile/15E148 Safari/604.1 test test"")
OpacityCore.presentBrowser()
```

Google should just show what your user agent is just by searching it. If you wouldn't mind testing it @ospfranco 