### PR TITLE
fix navigation to URI for android

### DIFF
--- a/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/InAppBrowserActivity.kt
+++ b/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/InAppBrowserActivity.kt
@@ -168,6 +168,12 @@ class InAppBrowserActivity : AppCompatActivity() {
                         ): GeckoResult<AllowOrDeny>? {
                             currentUrl = request.uri
                             addToVisitedUrls(request.uri)
+
+                            // we have to emit a `location_changed` event
+                            // so we can catch this event in lua
+                            // these types of events seem to be `navigation` events for iOS, though
+                            emitLocationEvent(request.uri)
+
                             return super.onLoadRequest(session, request)
                         }
 

--- a/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/InAppBrowserActivity.kt
+++ b/OpacityCore/src/main/kotlin/com/opacitylabs/opacitycore/InAppBrowserActivity.kt
@@ -168,11 +168,8 @@ class InAppBrowserActivity : AppCompatActivity() {
                         ): GeckoResult<AllowOrDeny>? {
                             currentUrl = request.uri
                             addToVisitedUrls(request.uri)
-
-                            // we have to emit a `location_changed` event
-                            // so we can catch this event in lua
-                            // these types of events seem to be `navigation` events for iOS, though
-                            emitLocationEvent(request.uri)
+                            
+                            emitNavigationEvent()
 
                             return super.onLoadRequest(session, request)
                         }


### PR DESCRIPTION
This attempts to solve the issue for redirects on Android.

Testing some more, I found out that there is a bigger discrepancy between iOS and Android. Whilst on iOS the `navigation` event seems to be triggered quite often, on Android that is NOT the case. Even for navigation to NON-URI's (navigation to pure URLs), on Android, it seems that those events are triggered as `location_changed` events.

I am open to how and when each one of these events should be sent

#### Update 1: 
Very rarely am I seeing the navigation event on Android as opposed to IOS.
It's mostly just the `location_changed` event on Android.
And while this wouldn't be a problem and we could just check for both `event.event == "navigation" or event.event == "location_changed"` so as to cater to both platforms, the long-term problem is that in doing so, if we want to extract things specific to the `.event == "navigation"`, we would have to do extra-work for `location_changed` as the `navigation `event gives out much more info (cookies, html_body, visited urls, yada yada)


