### PR TITLE
Add cookies from document.cookies

### DIFF
--- a/OpacityCore/src/main/assets/extension/background.js
+++ b/OpacityCore/src/main/assets/extension/background.js
@@ -1,3 +1,5 @@
+const cookieStore = {};
+
 browser.webRequest.onHeadersReceived.addListener(
   function (details) {
     let url = details.url;
@@ -24,13 +26,13 @@ browser.webRequest.onHeadersReceived.addListener(
     // Parse cookies
     let cookieDict = {};
     cookies.split("\n").forEach((cookie) => {
-      let parts = cookie.split(";").map(p => p.trim());
+      let parts = cookie.split(";").map((p) => p.trim());
 
       let [name, value] = parts[0].split("=");
 
       cookieDict[name] = value;
 
-      parts.slice(1).forEach(attr => {
+      parts.slice(1).forEach((attr) => {
         let [key, val] = attr.split("=");
         if (key.toLowerCase() === "domain") {
           /** RFC 6265
@@ -46,17 +48,66 @@ browser.webRequest.onHeadersReceived.addListener(
       });
     });
 
+    const domain = cookie_domain || request_domain;
+    if (!cookieStore[domain]) {
+      cookieStore[domain] = { cookies: {} };
+    }
+
+    Object.keys(cookieDict).forEach((name) => {
+      cookieStore[domain].cookies[name] = cookieDict[name];
+    });
 
     // Send cookies back to the app (GeckoView) via messaging
     browser.runtime.sendNativeMessage("gecko", {
       event: "cookies",
-      cookies: cookieDict,
-      domain: cookie_domain || request_domain,
+      cookies: cookieStore[domain].cookies,
+      domain: domain,
     });
   },
   { urls: ["<all_urls>"] }, // Intercept all URLs
   ["responseHeaders"]
 );
+
+// Handle messages from content script for document.cookies
+browser.runtime.onMessage.addListener(function (message, sender, _) {
+  if (message.type === "cookie_operation") {
+    try {
+      const domain = message.domain || new URL(sender.tab.url).hostname;
+
+      if (!domain) {
+        browser.runtime.sendNativeMessage("gecko", {
+          event: "cookies",
+          cookies: message.cookies,
+          domain: message.domain,
+        });
+
+        return;
+      }
+
+      if (!cookieStore[domain]) {
+        cookieStore[domain] = { cookies: {} };
+      }
+
+      Object.keys(message.cookies || {}).forEach((name) => {
+        const value = message.cookies[name];
+
+        cookieStore[domain].cookies[name] = value;
+      });
+
+      browser.runtime.sendNativeMessage("gecko", {
+        event: "cookies",
+        cookies: cookieStore[domain].cookies,
+        domain: domain,
+      });
+    } catch (err) {
+      browser.runtime.sendNativeMessage("gecko", {
+        event: "cookies",
+        cookies: message.cookies,
+        domain: message.domain,
+      });
+    }
+  }
+});
 
 browser.webNavigation.onDOMContentLoaded.addListener(function (details) {
   if (details.frameId === 0) {

--- a/OpacityCore/src/main/assets/extension/content.js
+++ b/OpacityCore/src/main/assets/extension/content.js
@@ -1,0 +1,103 @@
+const COOKIE_POLL_INTERVAL_MS = 500;
+
+let cookiePollIntervalId = null;
+let lastCookieState = document.cookie;
+
+const originalCookie = Object.getOwnPropertyDescriptor(
+  Document.prototype,
+  "cookie"
+);
+
+const originalSetter = originalCookie.set;
+
+const sendCookieData = (cookieData) => {
+  if (!browser || !browser.runtime || !browser.runtime.sendMessage) {
+    return;
+  }
+
+  browser.runtime.sendMessage({
+    type: "cookie_operation",
+    cookies: cookieData,
+    domain: window.location.hostname || "",
+  });
+};
+
+const cookieSetter = (value) => {
+  let result;
+
+  // call the original setter
+  try {
+    if (typeof originalSetter === "function") {
+      result = originalSetter.call(this, value);
+    }
+  } catch (error) {}
+
+  if (!value) {
+    return result;
+  }
+
+  const mainCookiePart = value.split(";")[0];
+  const cookieParts = mainCookiePart.split("=");
+
+  if (cookieParts.length >= 2) {
+    const cookieName = cookieParts[0].trim();
+    const cookieValue = cookieParts.slice(1).join("=").trim();
+
+    // send to background script
+    if (cookieName) {
+      const cookieData = { [cookieName]: cookieValue };
+      sendCookieData(cookieData);
+    }
+  }
+
+  return result;
+};
+
+// apply our new descriptor with the new setter
+Object.defineProperty(Document.prototype, "cookie", {
+  configurable: originalCookie.configurable,
+  enumerable: originalCookie.enumerable,
+  get: originalCookie.get,
+  set: cookieSetter,
+});
+
+// poll changes to document.cookies
+const pollForCookies = () => {
+  cookiePollIntervalId = setTimeout(() => {
+    try {
+      const currentCookieState = document.cookie;
+
+      if (currentCookieState === lastCookieState) {
+        pollForCookies();
+        return;
+      }
+
+      const parsedCookies = (() => {
+        const cookies = {};
+        if (!currentCookieState) return cookies;
+
+        currentCookieState.split(";").forEach((cookie) => {
+          const parts = cookie.trim().split("=");
+          if (parts.length >= 2) {
+            const name = parts[0].trim();
+            const value = parts.slice(1).join("=").trim();
+            if (name) {
+              cookies[name] = value;
+            }
+          }
+        });
+
+        return cookies;
+      })();
+
+      lastCookieState = currentCookieState;
+
+      sendCookieData(parsedCookies);
+      pollForCookies();
+    } catch (error) {
+      pollForCookies();
+    }
+  }, COOKIE_POLL_INTERVAL_MS);
+};
+
+pollForCookies();

--- a/OpacityCore/src/main/assets/extension/manifest.json
+++ b/OpacityCore/src/main/assets/extension/manifest.json
@@ -14,6 +14,14 @@
       "background.js"
     ]
   },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_start",
+      "all_frames": true
+    }
+  ],
   "permissions": [
     "webRequest",
     "activeTab",


### PR DESCRIPTION
We were only getting cookies from requests with `set-cookie`, some platforms need cookies that are set otherhow.