### PR TITLE
Better cookie parsing

### DIFF
--- a/OpacityCore/src/main/assets/extension/background.js
+++ b/OpacityCore/src/main/assets/extension/background.js
@@ -3,8 +3,7 @@ const cookieStore = {};
 browser.webRequest.onHeadersReceived.addListener(
   function (details) {
     let url = details.url;
-    let request_domain = new URL(url).hostname;
-    let cookie_domain;
+    let domain = new URL(url).hostname;
 
     let cookiesHeaders = details.responseHeaders.filter(
       (header) => header.name.toLowerCase() === "set-cookie"
@@ -20,51 +19,9 @@ browser.webRequest.onHeadersReceived.addListener(
       return;
     }
 
-    // cookies is a single string, e.g. "sampleCookie=sampleValue; Path=\/\nsampleCookie2=sampleValue2; Path=\/"
-    // We need to split and parse it to a single dictionary
-
-    let cookieDict = {};
-    cookies.split("\n").forEach((cookie) => {
-      let parts = cookie.split(";").map((p) => p.trim());
-
-      let first = parts[0];
-      let eqIndex = first.indexOf("=");
-      if (eqIndex !== -1) {
-        let name = first.slice(0, eqIndex);
-        let value = first.slice(eqIndex + 1);
-        cookieDict[name] = value;
-      }
-
-      parts.slice(1).forEach((attr) => {
-        let [key, ...rest] = attr.split("=");
-        let val = rest.join("=") || true;
-        if (key.toLowerCase() === "domain") {
-          /** RFC 6265
-           * If the first character of the attribute-value string is %x2E ("."):
-            Let cookie-domain be the attribute-value without the leading %x2E
-            (".") character.
-           */
-          if (val.startsWith(".")) {
-            val = val.substring(1);
-          }
-          cookie_domain = val;
-        }
-      });
-    });
-
-    const domain = cookie_domain || request_domain;
-    if (!cookieStore[domain]) {
-      cookieStore[domain] = { cookies: {} };
-    }
-
-    Object.keys(cookieDict).forEach((name) => {
-      cookieStore[domain].cookies[name] = cookieDict[name];
-    });
-
-    // Send cookies back to the app (GeckoView) via messaging
     browser.runtime.sendNativeMessage("gecko", {
       event: "cookies",
-      cookies: cookieStore[domain].cookies,
+      cookies: cookies,
       domain: domain,
     });
   },

--- a/OpacityCore/src/main/assets/extension/background.js
+++ b/OpacityCore/src/main/assets/extension/background.js
@@ -24,14 +24,19 @@ browser.webRequest.onHeadersReceived.addListener(
     // Parse cookies
     let cookieDict = {};
     cookies.split("\n").forEach((cookie) => {
-      let parts = cookie.split(";").map(p => p.trim());
+      let parts = cookie.split(";").map((p) => p.trim());
 
-      let [name, value] = parts[0].split("=");
+      let first = parts[0];
+      let eqIndex = first.indexOf("=");
+      if (eqIndex !== -1) {
+        let name = first.slice(0, eqIndex);
+        let value = first.slice(eqIndex + 1);
+        cookieDict[name] = value;
+      }
 
-      cookieDict[name] = value;
-
-      parts.slice(1).forEach(attr => {
-        let [key, val] = attr.split("=");
+      parts.slice(1).forEach((attr) => {
+        let [key, ...rest] = attr.split("=");
+        let val = rest.join("=") || true;
         if (key.toLowerCase() === "domain") {
           /** RFC 6265
            * If the first character of the attribute-value string is %x2E ("."):
@@ -45,7 +50,6 @@ browser.webRequest.onHeadersReceived.addListener(
         }
       });
     });
-
 
     // Send cookies back to the app (GeckoView) via messaging
     browser.runtime.sendNativeMessage("gecko", {


### PR DESCRIPTION
Sofi use this as their auth cookie
`SOFI_SESSION=b36c508010f69cbda3bbff98a38f733f27e7b581-fpSessionId=ca839b58-3777-42ab-b8be-094d9b008f1deyJraWQiOiJmMzRiN2YiLCJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzd3QiOiIwYzYxYTQ0OC1kNmE2LTRjNWUtOTUzMi04NDI2ZGIxY2M0OWMifQ.fjRKOLvzPAZHQNOIyxcUsOCYiRPdunb0jBrkzpRunWs_v_j0ChFE-kiBw2ZUTYEpxOJdclTRVwhwovkeKn-Img&csrfToken=d64f5dd4397bdab7a8745c062146bb3189e621f9-1759355657383-0ee1314680be7272a4e06db7&uuid=sofi-apps-51424963-663d2545-8173-4a7b-a295-b5a71341a947-global&TMX_SESSION=f0ed8674-dab1-4016-9808-fb1a8e0d2006`

The parsing fails because there's extra `=` in the value only taking `b36c508010f69cbda3bbff98a38f733f27e7b581-fpSessionId` as the value