### PR TITLE
Modify compilation params to support 16kb pages

### DIFF
--- a/OpacityCore/build.gradle
+++ b/OpacityCore/build.gradle
@@ -7,6 +7,7 @@ plugins {
 android {
     namespace 'com.opacitylabs.opacitycore'
     compileSdk 35
+    ndkVersion '27.1.12297006'
 
     defaultConfig {
         minSdk 24

--- a/OpacityCore/src/main/cpp/CMakeLists.txt
+++ b/OpacityCore/src/main/cpp/CMakeLists.txt
@@ -17,3 +17,6 @@ target_link_libraries(${CMAKE_PROJECT_NAME}
     sdk
     android
     log)
+
+target_link_options(${CMAKE_PROJECT_NAME} PRIVATE
+    "-Wl,-z,max-page-size=16384")

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 android {
     namespace = "com.opacitylabs.opacitycoreexample"
     compileSdk = 35
-    // ndkVersion = 26.3.11579264
+    ndkVersion = "27.1.12297006"
 
     defaultConfig {
         applicationId = "com.opacitylabs.opacitycoreexample"


### PR DESCRIPTION
Should take care of the issue mentioned here:

https://github.com/OpacityLabs/react-native-opacity/issues/19

All new libraries/apps require 16kb pages support. We did take care of the Rust lib compilation, but not of the android library itself.

What surprises me is we didn't catch this internally. I guess you guys are only developing in iOS and not publishing any apps on Android?